### PR TITLE
Revert "Bump actions/download-artifact from 4 to 6 in /.github/workflows"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
     permissions:
       id-token: write # for PyPI trusted publishing
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Reverts Souny-hub/GWD-Net#8